### PR TITLE
write 0 to enable rather than disable

### DIFF
--- a/src/core/pwm.c
+++ b/src/core/pwm.c
@@ -229,7 +229,7 @@ int pwm_disable(const uint8_t pwm_pin)
         return -1;
     }
 
-    return write_str_pwm_file(pwm_pin, "disable", "0");
+    return write_str_pwm_file(pwm_pin, "enable", "0");
 }
 
 int pwm_release(const uint8_t pwm_pin)


### PR DESCRIPTION
'disable' does not exist as a file. You either write 0 or 1 to the 'enable' file.

Commited by matt.atkinson@imgtec.com