### PR TITLE
Optimize adding elements to linked list

### DIFF
--- a/src/core/gpio_monitor.c
+++ b/src/core/gpio_monitor.c
@@ -187,11 +187,9 @@ static int add_inotify_watch(uint8_t gpio_pin)
         inotify_watch_list_head = watch;
         pthread_mutex_unlock(&inotify_watch_mutex);
     } else {
-        struct inotify_watch *last = inotify_watch_list_head;
-        while (last->next)
-            last = last->next;
         pthread_mutex_lock(&inotify_watch_mutex);
-        last->next = watch;
+        watch->next = inotify_watch_list_head;
+        inotify_watch_list_head = watch;
         pthread_mutex_unlock(&inotify_watch_mutex);
     }
 
@@ -335,11 +333,9 @@ int gpio_monitor_add_callback(uint8_t gpio_pin, uint8_t event_mask, void(*callba
         gpio_watch_list_head = watch;
         pthread_mutex_unlock(&gpio_watch_mutex);
     } else {
-        struct gpio_watch *last = gpio_watch_list_head;
-        while (last->next)
-            last = last->next;
         pthread_mutex_lock(&gpio_watch_mutex);
-        last->next = watch;
+        watch->next = gpio_watch_list_head;
+        gpio_watch_list_head = watch;
         pthread_mutex_unlock(&gpio_watch_mutex);
     }
 


### PR DESCRIPTION
Instead of traversing to the end of the list to add new node
add the node in the begining

Signed-off-by: Avinash Tahakik <avinashtahakik@imgtec.com>